### PR TITLE
URL encoding for API search & spaces in pop-result

### DIFF
--- a/app/functions/functions.tsx
+++ b/app/functions/functions.tsx
@@ -36,7 +36,7 @@ export default async function getApi(input: string, type: string) {
     try {
       let response = await fetch(
         "http://api.geonames.org/searchJSON?username=weknowit&featureClass=P&name=" +
-          input
+          encodeURIComponent(input)
       );
       let result = (await response.json()) as ApiResponse;
 
@@ -59,7 +59,7 @@ export default async function getApi(input: string, type: string) {
     try {
       let response = await fetch(
         "http://api.geonames.org/searchJSON?username=weknowit&adminCode1=00&name=" +
-          input
+          encodeURIComponent(input)
       );
       let result = (await response.json()) as ApiResponse;
 

--- a/app/screens/PopulationResult.tsx
+++ b/app/screens/PopulationResult.tsx
@@ -13,7 +13,9 @@ export default function PopulationResult({ route }: PopulationResultProp) {
       </View>
       <View style={styles.populationDisplay}>
         <Text style={styles.populationHeadline}>POPULATION</Text>
-        <Text style={styles.populationCount}>{route.params.population}</Text>
+        <Text style={styles.populationCount}>
+          {route.params.population.toLocaleString()}
+        </Text>
       </View>
     </View>
   );


### PR DESCRIPTION
- Spaces between numbers to be more readable. 